### PR TITLE
Add .then to cursors

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,12 @@ Cursor.prototype.size = function(callback) {
 	return this.count(true).nodeify(callback);
 };
 
+// If .then is called on a cursor, invoke toArray() and return promise
+Cursor.prototype.then = function() {
+	var promise = this.toArray()
+	return promise.then.apply(promise, arguments);
+};
+
 
 Cursor.prototype._apply = function(fn, args) {
 	// separate callback and args.
@@ -159,7 +165,6 @@ Cursor.prototype._config = function(fn, args) {
 		return this;
 	}
 };
-
 
 // Proxy for the native collection prototype that normalizes method names and
 // arguments to fit the mongo shell.

--- a/tests/test-cursor-then.js
+++ b/tests/test-cursor-then.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+var insert = require('./insert');
+
+insert([{
+  hello:'world1'
+},{
+  hello:'world2'
+}], function(db, done) {
+  var cursor = db.a.find();
+  cursor.then(function (docs) {
+    assert.equal(docs[0].hello, 'world1');
+    assert.equal(docs[1].hello, 'world2');
+  })
+  .catch(function(err) {
+    assert(err instanceof Error);
+    done();
+  })
+  .then(done);
+});


### PR DESCRIPTION
No need for the extra .toArray() call. With this patch, you can now return cursors and if the calling context expects a promise instead, it'll just work.

This is used by other libraries that also chain methods that eventually execute an async task. 

For example: [supertest-as-promised](https://github.com/WhoopInc/supertest-as-promised).
