### PR TITLE
mongodb dependency updated to 1.4.35

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "readable-stream": "~1.1.8",
-    "mongodb": "1.4.0",
+    "mongodb": "^1.4.35",
     "q": "~0.9.7"
   },
   "scripts": {


### PR DESCRIPTION
Mongo native driver updated to version more than 1.4.29 for authorization in MongoDB 3.0.