### PR TITLE
Add db.db function back in

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,8 @@ createDatabase.compatible = function () {
       });
   };
 
+  Database.prototype.db = Database.prototype.getSiblingDb;
+
   return this;
 };
 

--- a/lib/Database.js
+++ b/lib/Database.js
@@ -14,7 +14,12 @@ const MongoCR = mongodb.MongoCR;
 export default class Database {
   constructor(connectionString, collections) {
     let self = this;
-    self.config = parseConnectionString(connectionString);
+
+    if (typeof connectionString === 'string') {
+      self.config = parseConnectionString(connectionString);
+    } else {
+      self.config = connectionString;
+    }
 
     let db_options = self.config.db_options;
     let writeConcern = { w: 1 };
@@ -174,6 +179,13 @@ export default class Database {
 
   async removeUser(username) {
     return await this.dropUser(username);
+  }
+
+
+  async db(dbName, collections) {
+    let db2 = new Database(_.assign({}, this.config, {dbName}), collections);
+    db2._serverPromise = await this.connect();
+    return db2;
   }
 
 

--- a/lib/Database.js
+++ b/lib/Database.js
@@ -182,7 +182,7 @@ export default class Database {
   }
 
 
-  async db(dbName, collections) {
+  async getSiblingDb(dbName, collections) {
     let db2 = new Database(_.assign({}, this.config, {dbName}), collections);
     db2._serverPromise = await this.connect();
     return db2;

--- a/test/Database.js
+++ b/test/Database.js
@@ -111,4 +111,13 @@ describe('Database', function () {
       await db.stats();
     });
   });
+
+  describe('getSiblingDb', function () {
+    it('succeeds', async function () {
+      let db2 = await db.getSiblingDb('test');
+      expect(db2).to.exist;
+      expect(db2._serverPromise).to.exist;
+      expect(db2.config.dbName).to.equal('test');
+    });
+  });
 });


### PR DESCRIPTION
The previous version had a `db.db(dbName)` function, which has been removed.

This PR adds it back in again.