### PR TITLE
Fix ID queries

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -9,11 +9,22 @@ const Code = mongodb.BSON.Code;
 const ObjectID = mongodb.BSON.ObjectID;
 
 
-var indexName = function(index) {
+function indexName(index) {
   return Object.keys(index).map(function(key) {
     return key + '_' + index[key];
   }).join('_');
-};
+}
+
+
+function makeQuery(query) {
+  if (typeof query === 'undefined') {
+    return {};
+  } else if (query instanceof ObjectID || typeof query !== 'object') {
+    return {_id: query};
+  } else {
+    return query;
+  }
+}
 
 
 export default class Collection {
@@ -87,7 +98,7 @@ export default class Collection {
 
 
   find(query, projection, options) {
-    query = query || {};
+    query = makeQuery(query);
     projection = projection || null;
 
     options = _.extend({
@@ -110,7 +121,8 @@ export default class Collection {
 
 
   async findOne(query, projection) {
-    let cursor = this.find.apply(this, arguments).limit(1);
+    query = makeQuery(query);
+    let cursor = this.find(query, projection).limit(1);
     let result = await cursor.next();
     return result;
   }
@@ -218,6 +230,8 @@ export default class Collection {
 
 
   async remove(query, justOne) {
+    query = makeQuery(query);
+
     if (arguments.length === 0) {
       query = {};
     }
@@ -271,6 +285,8 @@ export default class Collection {
 
 
   async update(query, update, options) {
+    query = makeQuery(query);
+
     let self = this;
     if (!options) {
       options = {};

--- a/test/Collection.js
+++ b/test/Collection.js
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import Database from '../lib/Database';
 import Cursor from '../lib/Cursor';
+import {ObjectId} from '../index.js';
 
 require('bluebird').longStackTraces();
 
@@ -132,6 +133,22 @@ describe('Collection', function () {
       expect(result.hello).to.be.undefined;
       expect(result.another).to.equal('value');
     });
+
+    it('assumes the query is for _id if it is an ObjectId', async function () {
+      let id = new ObjectId();
+      await collection.insert({_id: id, hello: 'world'}, {hello: 'kitty'});
+      let results = await collection.find(id);
+      expect(results).to.have.length(1);
+      expect(results[0].hello).to.equal('world');
+    });
+
+    it('assumes the query is for _id if it is not an object', async function () {
+      let id = 1;
+      await collection.insert({_id: id, hello: 'world'}, {hello: 'kitty'});
+      let results = await collection.find(id);
+      expect(results).to.have.length(1);
+      expect(results[0].hello).to.equal('world');
+    });
   });
 
   describe('findAndModify', function () {
@@ -235,6 +252,20 @@ describe('Collection', function () {
       let result = await collection.findOne();
       expect(result.id).to.equal(1);
       expect(result.hello).to.equal('you');
+    });
+
+    it('assumes the query is for _id if it is an ObjectId', async function () {
+      let id = new ObjectId();
+      await collection.insert({_id: id, hello: 'world'}, {hello: 'kitty'});
+      let result = await collection.findOne(id);
+      expect(result.hello).to.equal('world');
+    });
+
+    it('assumes the query is for _id if it is not an object', async function () {
+      let id = 1;
+      await collection.insert({_id: id, hello: 'world'}, {hello: 'kitty'});
+      let result = await collection.findOne(id);
+      expect(result.hello).to.equal('world');
     });
   });
 
@@ -382,6 +413,20 @@ describe('Collection', function () {
       result = await collection.find({type: 'water'});
       expect(result.length).to.equal(0);
     });
+
+    it('assumes the query is for _id if it is an ObjectId', async function () {
+      let id = new ObjectId();
+      await collection.insert({_id: id, hello: 'world'});
+      await collection.remove(id);
+      expect(await collection.findOne(id)).to.not.exist;
+    });
+
+    it('assumes the query is for _id if it is not an object', async function () {
+      let id = 1;
+      await collection.insert({_id: id, hello: 'world'});
+      await collection.remove(id);
+      expect(await collection.findOne(id)).to.not.exist;
+    });
   });
 
   describe('save', function () {
@@ -428,6 +473,22 @@ describe('Collection', function () {
 
       let cmp = await collection.find({updated: true});
       expect(cmp.length).to.equal(2);
+    });
+
+    it('assumes the query is for _id if it is an ObjectId', async function () {
+      let id = new ObjectId();
+      await collection.insert({_id: id, hello: 'world'});
+      await collection.update(id, {$set: {hello: 'kitty'}});
+      let result = await collection.findOne(id);
+      expect(result.hello).to.equal('kitty');
+    });
+
+    it('assumes the query is for _id if it is not an object', async function () {
+      let id = 1;
+      await collection.insert({_id: id, hello: 'world'});
+      await collection.update(id, {$set: {hello: 'kitty'}});
+      let result = await collection.findOne(id);
+      expect(result.hello).to.equal('kitty');
     });
   });
 });


### PR DESCRIPTION
Previously you could call `collection.findOne` with just an `ObjectId` as a query, and it would assume you wanted to query on the `_id` field.

This PR restores this functionality, and also extends the assumption to any non-object query.