### PR TITLE
Remove bluebird promises

### DIFF
--- a/lib/Cursor.js
+++ b/lib/Cursor.js
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import {Readable} from 'readable-stream';
 import _ from 'lodash';
 

--- a/lib/Database.js
+++ b/lib/Database.js
@@ -1,4 +1,3 @@
-import Promise from 'bluebird';
 import mongodb from 'mongodb-core';
 import parseConnectionString from 'parse-mongo-url';
 import _ from 'lodash';

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   ],
   "dependencies": {
     "babel-runtime": "^5.5.5",
-    "bluebird": "^2.9.27",
     "harmony-proxy": "0.0.2",
     "lodash": "^3.9.3",
     "mongodb-core": "^1.1.33",
@@ -30,6 +29,7 @@
   },
   "devDependencies": {
     "babel": "^5.5.5",
+    "bluebird": "^2.9.27",
     "chai": "^3.0.0",
     "grunt": "^0.4.5",
     "grunt-babel": "^5.0.1",

--- a/test/Cursor.js
+++ b/test/Cursor.js
@@ -214,5 +214,21 @@ describe('Cursor', function () {
       expect(result).to.be.an.instanceof(Array);
       expect(result.length).to.equal(4);
     });
+
+    it('should be able to handle lots of documents', async function () {
+      const docsToInsert = [], numDocs = 600;
+      for (let i = 0; i < numDocs; i++) {
+        docsToInsert[i] = {
+          i,
+          name: `Pokemon ID #${i}`
+        };
+      }
+      await collection.insert(docsToInsert);
+
+      let result = await collection.find().toArray();
+
+      expect(result).to.be.an.instanceof(Array);
+      expect(result.length).to.equal(numDocs);
+    });
   });
 });


### PR DESCRIPTION
This PR addresses #39 which seems to stem from the usage of bluebird promises. Bluebird is removed as a dependency (and corejs/BabelJS promises are used instead) and a performance test is added.
