### PR TITLE
Align aggregate api with mongo docs

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -37,17 +37,15 @@ export default class Collection {
   }
 
 
-  async aggregate() {
-    let pipeline = Array.prototype.slice.call(arguments);
-    return (await this.runCommand('aggregate', {pipeline})).result;
+  async aggregate(pipeline, options) {
+    return (await this.runCommand('aggregate', { pipeline, options })).result;
   }
 
 
-  aggregateCursor() {
-    let pipeline = Array.prototype.slice.call(arguments);
+  aggregateCursor(pipeline) {
     return new Cursor(this, this.fullCollectionName, {
+      pipeline,
       aggregate: this.collectionName,
-      pipeline: pipeline,
       cursor: {batchSize: 1000}
     }, {cursor: {batchSize: 1000}});
   }

--- a/test/Collection.js
+++ b/test/Collection.js
@@ -25,7 +25,7 @@ describe('Collection', function () {
         { name: 'Lapras', type: 'water' }
       ]);
 
-      let result = await collection.aggregate({$group: {_id: '$type'}});
+      let result = await collection.aggregate([{$group: {_id: '$type'}}]);
       expect(result).to.deep.have.members([{_id: 'water' }, {_id: 'fire'}]);
     });
   });
@@ -39,7 +39,7 @@ describe('Collection', function () {
         { name: 'Lapras', type: 'water' }
       ]);
 
-      let cursor = collection.aggregateCursor({$group: {_id: '$type'}});
+      let cursor = collection.aggregateCursor([{$group: {_id: '$type'}}]);
       expect(cursor).to.be.an.instanceof(Cursor);
       let result = await cursor.toArray();
       expect(result).to.deep.have.members([{_id: 'water' }, {_id: 'fire'}]);


### PR DESCRIPTION
This PR addresses #27 -- bringing the `aggregate()` api into line with the official mongo api. The only change is moving the pipeline from `arguments` to an explicitly passed array. Mongo docs for reference: https://docs.mongodb.org/manual/reference/method/db.collection.aggregate/
