### PR TITLE
Bump mongodb-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bluebird": "^2.9.27",
     "harmony-proxy": "0.0.2",
     "lodash": "^3.9.3",
-    "mongodb-core": "^1.1.33",
+    "mongodb-core": "^1.2.30",
     "parse-mongo-url": "^1.1.0",
     "readable-stream": "~1.1.8"
   },


### PR DESCRIPTION
There is a fix in 1.2.30 that should fix errors when reconnecting to a replicaSet.
