### PR TITLE
Array + Options notation for aggregate method

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -38,8 +38,13 @@ export default class Collection {
 
 
   async aggregate() {
-    let pipeline = Array.prototype.slice.call(arguments);
-    return (await this.runCommand('aggregate', {pipeline})).result;
+    let pipeline = Array.prototype.slice.call(arguments),
+      options = {pipeline};
+    if(Array.isArray(pipeline[0])){
+      if(pipeline[1]) options = pipeline[1];
+      options.pipeline = pipeline[0];
+    }
+    return (await this.runCommand('aggregate', options)).result;
   }
 
 


### PR DESCRIPTION
Allow the official MongoDB notation `db.collection.aggregate( pipeline [, options] )`, using Array pipeline and giving the ability to pass options.
Custom `db.collection.aggregate( step1, step2, … )` still usable.