### PR TITLE
Align aggregate api with mongo docs without breaking

### DIFF
--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -39,20 +39,21 @@ export default class Collection {
 
   async aggregate() {
     let pipeline = Array.prototype.slice.call(arguments),
-      options = {pipeline};
+      options = {};
     if(Array.isArray(pipeline[0])){
       if(pipeline[1]) options = pipeline[1];
-      options.pipeline = pipeline[0];
+      pipeline = pipeline[0];
     }
-    return (await this.runCommand('aggregate', options)).result;
+    return (await this.runCommand('aggregate', {pipeline, options})).result;
   }
 
 
   aggregateCursor() {
     let pipeline = Array.prototype.slice.call(arguments);
+    if(Array.isArray(pipeline[0])) pipeline = pipeline[0];
     return new Cursor(this, this.fullCollectionName, {
       aggregate: this.collectionName,
-      pipeline: pipeline,
+      pipeline,
       cursor: {batchSize: 1000}
     }, {cursor: {batchSize: 1000}});
   }

--- a/lib/Collection.js
+++ b/lib/Collection.js
@@ -38,8 +38,13 @@ export default class Collection {
 
 
   async aggregate() {
-    let pipeline = Array.prototype.slice.call(arguments);
-    return (await this.runCommand('aggregate', {pipeline})).result;
+    let pipeline = Array.prototype.slice.call(arguments),
+      options = {pipeline};
+    if(Array.isArray(pipeline[0])){
+      if(pipeline[1]) options = pipeline[1];
+      options.pipeline = pipeline[0];
+    }
+    return (await this.runCommand('aggregate', options)).result;
   }
 
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "q"
   ],
   "license": "MIT",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "repository": "git://github.com/gordonmleigh/promised-mongo.git",
   "author": "Gordon Mackenzie-Leigh <gordon@stugo.co.uk>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "bluebird": "^2.9.27",
     "harmony-proxy": "0.0.2",
     "lodash": "^3.9.3",
-    "mongodb-core": "^1.1.33",
+    "mongodb-core": "1.1.33",
     "parse-mongo-url": "^1.1.0",
     "readable-stream": "~1.1.8"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "promised-mongo",
+  "name": "pr0mised-m0ng0",
   "description": "Easy to use module that implements the mongo api and supports promises",
   "keywords": [
     "mongo",
@@ -9,7 +9,7 @@
     "q"
   ],
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "2.0.3",
   "repository": "git://github.com/gordonmleigh/promised-mongo.git",
   "author": "Gordon Mackenzie-Leigh <gordon@stugo.co.uk>",
   "contributors": [


### PR DESCRIPTION
Changes the `db.collection.aggregate()` api to accept both the custom `aggregate( step1, step2, …)` and the official mongo `aggregate( pipeline, options )` notations.

The `aggregate()` should accept the pipeline as a string, allowing to pass options object.
Does the same as #41 , but keeping compatibility with current notation.

Mongo docs for reference: https://docs.mongodb.org/manual/reference/method/db.collection.aggregate/